### PR TITLE
Removing redundant `args`, adding sample file upload.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,13 @@ jobs:
     steps:
       - name: Checkout 
         uses: actions/checkout@master
+      - name: Get sample .apk for test purposes
+        run: wget https://github.com/appium/appium/raw/master/sample-code/apps/ApiDemos-debug.apk
       - name: Upload artefact to Firebase Distribution  
         uses: ./
         with:
-          appId: Test Name 
-          token: Test Token
-          groups: Test Group 
-          file: Test File
+          appId: ${{secrets.FIREBASE_APP_ID}} 
+          token: ${{secrets.FIREBASE_TOKEN}} 
+          groups: Testers 
+          file: ApiDemos-debug.apk
+ 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Example workflow for Firebase Distribution action
+name: Sample workflow for Firebase Distribution action
 on: [push]
 jobs:
   run:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Firebase Distribution Github Action
+# Firebase App Distribution Github Action
 
-This action uploads artefacts (.apk or .ipa) to Firebase Distribution.
+This action uploads artefacts (.apk or .ipa) to Firebase App Distribution.
 
 ## Inputs
 
@@ -27,12 +27,10 @@ Release notes visible on release page. If not specified, plugin will add last co
  - author
  - message
 
-
-
 ## Example usage
 
 ```
-name: Build, code quality, tests 
+name: Build & upload to Firebase App Distribution 
 
 on: [push]
 
@@ -49,7 +47,7 @@ jobs:
         java-version: 1.8
     - name: build release 
       run: ./gradlew assembleRelease
-    - name: upload artefact to Firebase Distribution
+    - name: upload artefact to Firebase App Distribution
       uses: wzieba/Firebase-Distribution-Github-Action@v1.0.0
       with:
         appId: ${{secrets.FIREBASE_APP_ID}}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firebase App Distribution Github Action
+# Firebase App Distribution Github Action ![](https://github.com/wzieba/Firebase-Distribution-Github-Action/workflows/Sample%20workflow%20for%20Firebase%20Distribution%20action/badge.svg)
 
 This action uploads artefacts (.apk or .ipa) to Firebase App Distribution.
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Firebase Distribution'
-description: 'GitHub Action that uploads artefacts to Firebase Distribution'
+name: 'Firebase App Distribution'
+description: 'GitHub Action that uploads artefacts to Firebase App Distribution'
 author: 'Wojciech Zięba <@wzieba>'
 inputs: 
   appId:
@@ -23,9 +23,3 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.app }}
-    - ${{ inputs.token }}
-    - ${{ inputs.groups }}
-    - ${{ inputs.file }}
-    - ${{ inputs.releaseNotes }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 MESSAGE="";
-if [[ -z $INPUT_RELEASENOTES ]]; then
+if [[ -z ${INPUT_RELEASENOTES} ]]; then
         MESSAGE="$(git log -1 --pretty=short)"
 else
-        MESSAGE=$INPUT_RELEASENOTES
+        MESSAGE=${INPUT_RELEASENOTES}
 fi
 
 firebase appdistribution:distribute "$INPUT_FILE" --app "$INPUT_APPID" --token "$INPUT_TOKEN" --groups "$INPUT_GROUPS" --release-notes "$MESSAGE"


### PR DESCRIPTION
After further digging into GithubAction's documentation I've realized, that having `args` [is redundant](https://help.github.com/en/articles/metadata-syntax-for-github-actions#args) on our case. This PR removes it.

I've included also uploading sample .apk file downloaded from [apium](https://github.com/appium/appium) repository. This allows us to have 100% sure that plugin works.