### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ jobs:
       with:
         appId: ${{secrets.FIREBASE_APP_ID}}
         token: ${{secrets.FIREBASE_TOKEN}}
-        group: testers
+        groups: testers
         file: app/build/outputs/apk/release/app-release-unsigned.apk
 ```


### PR DESCRIPTION
Typo in word `group` - should be `groups`

Fixes #4