### PR TITLE
Update node to 14.4.0, use replace npm with yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:12.10.0-alpine
+FROM node:14.4.0-alpine3.12
 
 WORKDIR /app
 COPY . /app
 
-RUN npm install -g firebase-tools \
+RUN yarn global add firebase-tools \
     && apk update \
     && apk add git 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     - name: build release 
       run: ./gradlew assembleRelease
     - name: upload artifact to Firebase App Distribution
-      uses: wzieba/Firebase-Distribution-Github-Action@v1.2.1
+      uses: wzieba/Firebase-Distribution-Github-Action@v1
       with:
         appId: ${{secrets.FIREBASE_APP_ID}}
         token: ${{secrets.FIREBASE_TOKEN}}


### PR DESCRIPTION
This PR resolves permission issue described in #15. I didn't explore the real cause (yet) but bumping up node.js version to 14.4.0 and replacing `npm` with `yarn` fixes the issue that I was able to reproduce here https://github.com/wzieba/Firebase-Distribution-Github-Action/runs/792992750

I also update README.md to demonstrate how user can reference a major release instead of specific version (so we can support everyone with hotfixes like this without requiring client action). https://help.github.com/en/actions/creating-actions/about-actions#using-tags-for-release-management

Thank you @naushad-madakiya for reporting this one.

Resolves #15 