### PR TITLE
Add config to allow service credential file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ This action uploads artifacts (.apk or .ipa) to Firebase App Distribution.
 
 **Required** App id can be found on the General Settings page
 
+## Either Firebase Token or Service Credentials File, one is enough.
+
 ### `token`
 
 **Required** Upload token - see Firebase CLI Reference (tldr; run `firebase login:ci` command to get your token).
+
+### `serviceCredentialsFile`
+
+**Required** Service Credentials File - The path or HTTP URL to your [service account](https://firebase.google.com/docs/app-distribution/android/distribute-gradle#authenticate_using_a_service_account) private key JSON file.
+Required only if you use service account authentication.
 
 ### `file`
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,10 @@ inputs:
     required: true
   token:
     description: 'Upload token - see Firebase CLI Reference'
-    required: true
+    required: false
+  serviceCredentialsFile:
+    description: 'Service credential file'
+    required: false
   file:
     description: 'Artifact to upload (.apk or .ipa)'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,11 +14,18 @@ if [[ ${INPUT_RELEASENOTESFILE} ]]; then
         RELEASE_NOTES_FILE=${INPUT_RELEASENOTESFILE}
 fi
 
+if [ -n "${INPUT_SERVICECREDENTIALSFILE}" ] ; then
+    export GOOGLE_APPLICATION_CREDENTIALS="${INPUT_SERVICECREDENTIALSFILE}"
+fi
+
+if [ -n "${INPUT_TOKEN}" ] ; then
+    export FIREBASE_TOKEN="${INPUT_TOKEN}"
+fi
+
 firebase \
         appdistribution:distribute \
         "$INPUT_FILE" \
         --app "$INPUT_APPID" \
-        --token "$INPUT_TOKEN" \
         --groups "$INPUT_GROUPS" \
         ${RELEASE_NOTES:+ --release-notes "${RELEASE_NOTES}"} \
         ${INPUT_RELEASENOTESFILE:+ --release-notes-file "${RELEASE_NOTES_FILE}"} \


### PR DESCRIPTION
Firebase token would expose all the project under the account. 
By using a firebase service account credential, we can limit the scope of the access for the CI.