### PR TITLE
Add /github/workspace as a safe repository

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Required since https://github.blog/2022-04-12-git-security-vulnerability-announced
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 RELEASE_NOTES=""
 RELEASE_NOTES_FILE=""
 


### PR DESCRIPTION
Fixes #74 
Fixes #67 

This PR is a copy of #76 authored by @davidmigloz.

The reason I'm creating it is that I can't run CI tests because citing Github documentation:

> Secrets are not passed to workflows that are triggered by a pull request from a fork.