### PR TITLE
README Minor Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        java-version: 11
+        distribution: 'temurin'
+        cache: gradle
     - name: build release 
       run: ./gradlew assembleRelease
     - name: upload artifact to Firebase App Distribution
-      uses: wzieba/Firebase-Distribution-Github-Action@v1
+      uses: wzieba/Firebase-Distribution-Github-Action@v1.3.3
       with:
         appId: ${{secrets.FIREBASE_APP_ID}}
         token: ${{secrets.FIREBASE_TOKEN}}


### PR DESCRIPTION
Updated GitHub Actions to use the latest versions

I followed these 2 blog posts to setup Firebase Distribution with GitHub Actions for my project:
https://proandroiddev.com/continuous-integration-delivery-for-android-with-github-actions-part-1-b232ed2b1740
https://proandroiddev.com/continuous-integration-delivery-for-android-with-github-actions-part-2-ec69b6980389

It was outdated and this is a small change to help future setups.

It would be nice to use the latest release version dynamically in the sample usage but I'm not sure how to do it.