### PR TITLE
Fix missing `python` and `g++`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Get sample .apk for test purposes
-        run: wget https://github.com/appium/appium/raw/master/sample-code/apps/ApiDemos-debug.apk
+        run: wget https://github.com/appium/appium/raw/1.10/sample-code/apps/ApiDemos-debug.apk
       - name: Upload artifact to Firebase Distribution
         uses: ./
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM node:18-alpine3.15
 WORKDIR /app
 COPY . /app
 
-RUN yarn global add firebase-tools \
-    && apk update \
-    && apk add git 
+RUN apk update \
+    && apk add git g++ make python3 \
+    && yarn global add firebase-tools
 
 RUN chmod +x /app/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine3.14
+FROM node:18-alpine3.15
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
The action started to fail due to a lack of Python. I'm not 100% sure what happened because the Docker container has a fixed version (so nothing changed there) and I can't see information about breaking changes in `firebase-tools` [changelog](https://github.com/firebase/firebase-tools/releases) 🤷 .

Either way, this PR fixes the action.

Closes: #83 