### PR TITLE
Support service credential file from secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,4 +49,13 @@ jobs:
           file: ApiDemos-debug.apk
           debug: true
           serviceCredentialsFile: credential_file.json
+      - name: Upload artifact to Firebase Distribution using credential file content
+        uses: ./
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          groups: Testers
+          releaseNotesFile: README.md
+          file: ApiDemos-debug.apk
+          debug: true
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . /app
 
 RUN apk update \
-    && apk add git g++ make python3 \
+    && apk add bash git g++ make python3 \
     && yarn global add firebase-tools
 
 RUN chmod +x /app/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -11,16 +11,21 @@ This action uploads artifacts (.apk,.aab or .ipa) to Firebase App Distribution.
 
 **Required** App id can be found on the General Settings page
 
-## Either Firebase Token or Service Credentials File, one is enough.
-
 ### `token`
 
-**Required** Upload token - see Firebase CLI Reference (tldr; run `firebase login:ci` command to get your token).
+⚠️ Deprecated! Don't use it. Firebase team deprecated this option and it will soon be removed.
+
+Use `serviceCredentialsFileContent` instead. [Learn here how to generate one](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration).
+
+~**Required** Upload token - see Firebase CLI Reference (tldr; run `firebase login:ci` command to get your token).~
+
+### `serviceCredentialsFileContent`
+**Required** Content of Service Credentials private key JSON file. [Learn here how to generate one](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration).
 
 ### `serviceCredentialsFile`
 
-**Required** Service Credentials File - The path or HTTP URL to your [service account](https://firebase.google.com/docs/app-distribution/android/distribute-gradle#authenticate_using_a_service_account) private key JSON file.
-Required only if you use service account authentication.
+**Required** Service Credentials File - The path or HTTP URL to your Service Account private key JSON file.
+Required only if you don't use `serviceCredentialsFileContent`.
 
 ### `file`
 
@@ -69,7 +74,7 @@ jobs:
       uses: wzieba/Firebase-Distribution-Github-Action@v1
       with:
         appId: ${{secrets.FIREBASE_APP_ID}}
-        token: ${{secrets.FIREBASE_TOKEN}}
+        serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
         groups: testers
         file: app/build/outputs/apk/release/app-release-unsigned.apk
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,10 @@ inputs:
     description: 'Upload token - see Firebase CLI Reference'
     required: false
   serviceCredentialsFile:
-    description: 'Service credential file'
+    description: 'Service credentials file'
+    required: false
+  serviceCredentialsFileContent:
+    description: 'Content of service credentials file'
     required: false
   file:
     description: 'Artifact to upload (.apk or .ipa)'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,7 @@ if [ -n "${INPUT_SERVICECREDENTIALSFILECONTENT}" ] ; then
 fi
 
 if [ -n "${INPUT_TOKEN}" ] ; then
+    echo "⚠ This action will stop working with the next future major version of `firebase-tools`! Migrate to Service Account. See more: https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration"
     export FIREBASE_TOKEN="${INPUT_TOKEN}"
 fi
 
@@ -39,3 +40,6 @@ firebase \
         ${INPUT_RELEASENOTESFILE:+ --release-notes-file "${RELEASE_NOTES_FILE}"} \
         $( (( $INPUT_DEBUG )) && printf %s '--debug' )
 
+if [ -n "${INPUT_TOKEN}" ] ; then
+    echo "⚠ This action will stop working with the next future major version of `firebase-tools`! Migrate to Service Account. See more: https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Required since https://github.blog/2022-04-12-git-security-vulnerability-announced
 git config --global --add safe.directory $GITHUB_WORKSPACE
@@ -19,6 +19,11 @@ fi
 
 if [ -n "${INPUT_SERVICECREDENTIALSFILE}" ] ; then
     export GOOGLE_APPLICATION_CREDENTIALS="${INPUT_SERVICECREDENTIALSFILE}"
+fi
+
+if [ -n "${INPUT_SERVICECREDENTIALSFILECONTENT}" ] ; then
+    cat <<< "${INPUT_SERVICECREDENTIALSFILECONTENT}" > service_credentials_content.json
+    export GOOGLE_APPLICATION_CREDENTIALS="service_credentials_content.json"
 fi
 
 if [ -n "${INPUT_TOKEN}" ] ; then


### PR DESCRIPTION
Closes: #72 

This PR adds the possibility to use the content of the service account's private JSON key directly from GitHub secrets. Additionally, it adds a warning about soon-to-be deprecated `token` authentication.