### PR TITLE
Add support for testers parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Required only if you don't use `serviceCredentialsFileContent`.
 
 Distribution groups
 
+### `testers`
+
+Distribution testers. The email address of the testers you want to invite.
+
 ### `releaseNotes`
 
 Release notes visible on release page. If not specified, plugin will add last commit's

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   groups:
     description: 'Distribution groups'
     required: false
+  testers:
+    description: 'Distribution testers'
+    required: false
   releaseNotes:
     description: 'Release notes visible on release page'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ firebase \
         "$INPUT_FILE" \
         --app "$INPUT_APPID" \
         --groups "$INPUT_GROUPS" \
+        --testers "$INPUT_TESTERS" \
         ${RELEASE_NOTES:+ --release-notes "${RELEASE_NOTES}"} \
         ${INPUT_RELEASENOTESFILE:+ --release-notes-file "${RELEASE_NOTES_FILE}"} \
         $( (( $INPUT_DEBUG )) && printf %s '--debug' )


### PR DESCRIPTION
This PR adds support to use the `testers` Firebase parameter, i.e. you can provide email addresses you want to invite test. Allows for further flexibility than only using `groups`.