### PR TITLE
Action speed up by using a pre-built Docker image

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -12,25 +12,30 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Build and Publish head Docker image
+        uses: VaultVulp/gp-docker-action@1.6.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: vlazdra/firebase-distribution-github-action
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+            github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
+            image-name: firebase-distribution-github-action # Provide Docker image name
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v4
+      #   with:
+      #     images: vlazdra/firebase-distribution-github-action
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     file: ./Dockerfile
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
 # jobs:
 #   publish-docker-image:
 #     runs-on: ubuntu-latest

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
+          registry: ghcr.io
           username: ${{ secrets.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,22 +1,39 @@
-name: Action to publish a new version of the Firebase-Distribution-GitHub-Action Docker image to GitHub Container Registry
+name: Publish new Docker image to GHCR
 on:
   push:
     branches:
       - master
 jobs:
-  publish-docker-image:
+  docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ secrets.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Firebase-Distribution-GitHub-Action Docker image
-        run: |
-            docker build . --tag ghcr.io/vlazdra/firebase-distribution-github-action:latest
-            docker run ghcr.io/vlazdra/firebase-distribution-github-action:latest
-            docker push ghcr.io/vlazdra/firebase-distribution-github-action:latest
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: vlazdra/firebase-distribution-github-action:latest
+# jobs:
+#   publish-docker-image:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout the repository
+#         uses: actions/checkout@v3
+#       - name: Login to GitHub Container Registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.actor }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
+#       - name: Firebase-Distribution-GitHub-Action Docker image
+#         run: |
+#             docker build -t ghcr.io/vlazdra/firebase-distribution-github-action -f Dockerfile .
+#             docker push ghcr.io/vlazdra/firebase-distribution-github-action:latest

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -16,39 +16,5 @@ jobs:
         uses: VaultVulp/gp-docker-action@1.6.0
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
-            image-name: firebase-distribution-github-action # Provide Docker image name
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@v4
-      #   with:
-      #     images: vlazdra/firebase-distribution-github-action
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     file: ./Dockerfile
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-# jobs:
-#   publish-docker-image:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout the repository
-#         uses: actions/checkout@v3
-#       - name: Login to GitHub Container Registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.actor }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
-#       - name: Firebase-Distribution-GitHub-Action Docker image
-#         run: |
-#             docker build -t ghcr.io/vlazdra/firebase-distribution-github-action -f Dockerfile .
-#             docker push ghcr.io/vlazdra/firebase-distribution-github-action:latest
+            image-name: docker-image # Provide Docker image name
+            image-tag: v1.0.1

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,22 @@
+name: Action to publish a new version of the Firebase-Distribution-GitHub-Action Docker image to GitHub Container Registry
+on:
+  push:
+    branches:
+      - master
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Firebase-Distribution-GitHub-Action Docker image
+        run: |
+            docker build . --tag ghcr.io/vlazdra/firebase-distribution-github-action:latest
+            docker run ghcr.io/vlazdra/firebase-distribution-github-action:latest
+            docker push ghcr.io/vlazdra/firebase-distribution-github-action:latest

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -13,7 +15,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -17,4 +17,4 @@ jobs:
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
             image-name: docker-image # Provide Docker image name
-            image-tag: v1.0.1
+            additional-image-tags: v1.0.2

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -7,21 +7,27 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Check out the repo
+        uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: vlazdra/firebase-distribution-github-action
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
+          file: ./Dockerfile
           push: true
-          tags: vlazdra/firebase-distribution-github-action:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 # jobs:
 #   publish-docker-image:
 #     runs-on: ubuntu-latest

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.actor }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ branding:
   icon: 'send'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/vlazdra/firebase-distribution-github-action/firebase-distribution-github-action:latest'
+  image: 'docker://ghcr.io/vlazdra/firebase-distribution-github-action/docker-image:latest'

--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ branding:
   icon: 'send'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/vlazdra/firebase-distribution-github-action/firebase-distribution-github-action:latest'

--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ branding:
   icon: 'send'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/vlazdra/firebase-distribution-github-action/docker-image:latest'
+  image: 'docker://ghcr.io/wzieba/firebase-distribution-github-action/docker-image:latest'


### PR DESCRIPTION
Hi, came a cross this action and had no issues setting it up in my workflow. The only thing I was bummed about it the speed of the execution. So did a bit of research and came a cross this solution explained bellow.

The PR contains an action that when triggered creates a new Docker image and publishes it on GitHub Container Registry inside the active repository.
It defines a static version that is manually entered and automatically tags the latest image.
The second change is the main action itself, regarding the image that it's using. In the current example the main action uses the latest tag, but it can also use a static version depending on the definition.

Published packages look like this: [My packages](https://github.com/vlazdra/Firebase-Distribution-Github-Action/pkgs/container/firebase-distribution-github-action%2Fdocker-image)

And can be referenced inside the main action like so:
```yaml
image: 'docker://ghcr.io/wzieba/firebase-distribution-github-action/docker-image:latest'
```

> Note: Tested this whole implementation in my private repo.

The speed up is significant, (on average) there's a **7,5x** speed increase!
| Type  | Speed |
| ------------- | ------------- |
| With a pre-built Docker image  | ~20s  |
| Without a pre-build Docker image  | ~150s |



> P.S. Ignore my commit naming I really lacked inspiration for names when changing one liners. 😄 