### PR TITLE
make `firebase` the last command in the script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,3 @@ firebase \
         ${RELEASE_NOTES:+ --release-notes "${RELEASE_NOTES}"} \
         ${INPUT_RELEASENOTESFILE:+ --release-notes-file "${RELEASE_NOTES_FILE}"} \
         $( (( $INPUT_DEBUG )) && printf %s '--debug' )
-
-if [ -n "${INPUT_TOKEN}" ] ; then
-    echo ${TOKEN_DEPRECATED_WARNING_MESSAGE}
-fi


### PR DESCRIPTION
The exit code of the script should be the exit code of the `firebase ` command. The easiest way to achieve that is to have `firebase` be the last command in the script.

I've removed the (conditional) token deprecation warning output at the end of the script, because it's a duplicate, the warning is still given before the `firebase` command is executed.