### PR TITLE
feat: use pre-built Docker image from GH registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,6 @@ branding:
   icon: 'send'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: docker://ghcr.io/wzieba/firebase-distribution-github-action:sha-3379bab
+# Uncomment below for easier debugging
+# image: 'Dockerfile'


### PR DESCRIPTION
Closes: #115 

This PR updates the action to use pre-built Docker image from GitHub Package Registry of this repository ([link](https://github.com/wzieba/Firebase-Distribution-Github-Action/pkgs/container/firebase-distribution-github-action)).

It significantly improves the execution time: in test cases of this repository, from **~3m35s to 6s**. 

It was possible only because of contribution and POC from @vlazdra prepared in #107 . Thank you 🙏 