### PR TITLE
Update base image to node:20-alpine for firebase-tools compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.15
+FROM node:20-alpine
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
## issue
- https://github.com/wzieba/Firebase-Distribution-Github-Action/issues/145

## Summary

[firebase-tools 14.0.0](https://www.npmjs.com/package/firebase-tools) was released about 9 hours ago, and its Node.js engine requirement has been updated to ">=20.0.0 || >=22.0.0". The current Dockerfile uses node:18-alpine3.15, causing a compatibility error during the installation of firebase-tools.

## Changes

Update the base image in the Dockerfile from node:18-alpine3.15 to node:20-alpine

